### PR TITLE
Update rss.pl

### DIFF
--- a/rss.pl
+++ b/rss.pl
@@ -22,6 +22,7 @@ $rss->image(
 my $api = decode_json(get('https://www.twreporter.org/api/article?max_results=100&sort=-lastUpdate'));
 for (@{ $api->{_items} }) {
     $_->{story_link} =~ s/\s//g;
+    $_->{title} =~ s/[\x00-\x19]//g; # strip control characters
     $rss->add_item(
         title => $_->{title},
         description => $_->{excerpt},


### PR DESCRIPTION
The RSS was invalid because the title of https://www.twreporter.org/a/refinery-protesters contained a backspace...
